### PR TITLE
API Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🐳 Docker Simple CORS Proxy
 
-🐳 [Docker Image](https://hub.docker.com/r/obeoneorg/simple-cors-proxy) | 🔗 [TypingMind Plugin](https://cloud.typingmind.com/plugins/p-01HKBS6JY387AW48VJQ3JR50A2)
+🐳 [Docker Image](https://hub.docker.com/r/obeoneorg/simple-cors-proxy) | 🔗 [TypingMind Plugin](https://cloud.typingmind.com/plugins/p-01HMARRCP06S0B7Y6HRX1F9R0P)
 
 This is a simple CORS proxy server designed to work with the TypingMind plugin. It allows you to make cross-origin requests to any API without worrying about CORS restrictions.
 
@@ -15,7 +15,7 @@ This is a simple CORS proxy server designed to work with the TypingMind plugin. 
 
 The TypingMind plugin is a powerful tool that enhances the capabilities of GPT. With the TypingMind plugin, GPT can seamlessly make calls to any API without being restricted by CORS (Cross-Origin Resource Sharing) policies. This allows GPT to access external data sources and services, opening up a wide range of possibilities for integration and interaction.
 
-To use the TypingMind plugin, simply install go to the [TypingMind Plugin page](https://cloud.typingmind.com/plugins/p-01HKBS6JY387AW48VJQ3JR50A2) and click on Import.
+To use the TypingMind plugin, simply install go to the [TypingMind Plugin page](https://cloud.typingmind.com/plugins/p-01HMARRCP06S0B7Y6HRX1F9R0P) and click on Import.
 
 ## 🐳 Docker
 
@@ -69,6 +69,22 @@ npm start
 4. The server will be running on port 8080 by default. You can change the port by setting the `PORT` environment variable.
 
 ### Advanced Usage
+
+#### Authentication
+
+If you need to authenticate access to the proxy server, you can use the `PROXY_TOKEN` environment variable. You set the `PROXY_TOKEN` environment variable to the value of your API key, and the proxy server will check the API key in the `X-Proxy-Token` header.
+
+Example :
+
+```shell
+docker run -d --name simple-cors-proxy  -p 8080:8080 -e PROXY_TOKEN=YOUR_API_KEY obeoneorg/simple-cors-proxy
+```
+
+```shell
+curl -H "X-Proxy-Token: YOUR_API_KEY" -H "X-Url-Destination: http://example.com" http://localhost:8080/proxy
+```
+
+#### Headers Removal
 
 If you need to remove some headers (for example `X-Forwarded-For`), you can use the `x-headers-delete` header. For example, if you want to remove the `X-Forwarded-For` header, you can set the `x-headers-delete` header to `X-Forwarded-For`.
 

--- a/server.js
+++ b/server.js
@@ -31,6 +31,23 @@ const deleteHeadersMiddleware = (req, res, next) => {
     next();
 };
 
+// Middleware to check an optional API key
+const checkApiKeyMiddleware = (req, res, next) => {
+    'use strict';
+
+    const { headers } = req;
+    if (process.env.PROXY_TOKEN) {
+        if (req.headers['x-proxy-token'] !== process.env.PROXY_TOKEN) {
+            res.sendStatus(401);
+            return;
+        } else {
+            delete headers['x-proxy-token'];
+        }
+    }
+
+    next();
+}
+
 
 // Configuration for the proxy middleware
 const corsProxyOptions = {
@@ -92,6 +109,8 @@ const corsProxyOptions = {
 
 // Apply the middleware to delete headers
 app.use(deleteHeadersMiddleware);
+// Apply the middleware to check an optional API key
+app.use(checkApiKeyMiddleware);
 
 // Handle OPTIONS requests directly with user-friendly logging
 app.options('/proxy', (req, res) => {

--- a/server.js
+++ b/server.js
@@ -107,10 +107,6 @@ const corsProxyOptions = {
     
 };
 
-// Apply the middleware to delete headers
-app.use(deleteHeadersMiddleware);
-// Apply the middleware to check an optional API key
-app.use(checkApiKeyMiddleware);
 
 // Handle OPTIONS requests directly with user-friendly logging
 app.options('/proxy', (req, res) => {
@@ -121,6 +117,11 @@ app.options('/proxy', (req, res) => {
     res.header('Access-Control-Max-Age', '86400'); // 24 hours
     res.sendStatus(200);
 });
+
+// Apply the middleware to delete headers
+app.use(deleteHeadersMiddleware);
+// Apply the middleware to check an optional API key
+app.use(checkApiKeyMiddleware);
 
 // Apply the CORS proxy middleware to the path '/proxy'
 app.use('/proxy', createProxyMiddleware(corsProxyOptions));

--- a/server.js
+++ b/server.js
@@ -34,7 +34,7 @@ const deleteHeadersMiddleware = (req, res, next) => {
 
 // Configuration for the proxy middleware
 const corsProxyOptions = {
-    target: 'https://localhost:3000', // The target host (replaced by the X-Url-Destination header in router)
+    target: 'http://host_to_be_superseeded_by_router', // The target host (replaced by the X-Url-Destination header in router)
     changeOrigin: true,
     logLevel: 'debug', // Enable verbose logging for the proxy
     router: (req) => {


### PR DESCRIPTION
Added a new middleware function to check for an optional API key in the request headers. This middleware checks for the presence of an 'x-proxy-token' header and verifies it against the environment variable PROXY_TOKEN. If the token is missing or incorrect, a 401 status is returned. This provides an additional layer of security for certain routes.