### PR TITLE
fix(docker): repair the image build after the dependency upgrade

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+npm-debug.log
+.git
+.github
+.history
+test
+README.md
+docker-compose.yml

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -93,7 +93,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
+          # node:22-slim publishes no linux/s390x variant, so it is left out.
+          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
 # Use an official lightweight Node.js image as a parent image
-FROM node:24-slim
+FROM node:22-slim
 
-# Needed folder to run the app
+# HOME of the "nobody" user, needed at runtime by npm start
 RUN mkdir /nonexistent && \
     chown -R nobody:nogroup /nonexistent
-
-# Create a non-root user to run the app
-USER nobody
 
 # Set the working directory in the container
 WORKDIR /usr/src/app
@@ -14,16 +11,18 @@ WORKDIR /usr/src/app
 # Copy the package.json and package-lock.json files
 COPY package*.json ./
 
-# Install any needed packages specified in package.json
-RUN npm install
+# Install dependencies from the lockfile. This runs as root on purpose: the
+# unprivileged user cannot write node_modules into the working directory.
+RUN npm ci --omit=dev
 
 # Bundle the source code inside the Docker image
 COPY . .
 
+# Drop privileges only once every step needing write access is done
+USER nobody
 
 # The application will listen on port 8080, so expose it
 EXPOSE 8080
-
 
 # Define the command to run the app
 CMD [ "npm", "start" ]


### PR DESCRIPTION
Follow-up to #4, which left the Docker build red on main. Two separate
problems, plus one latent bug found on the way.

## The manifest failure

The workflow builds five platforms, but no current node tag publishes all
five: `arm/v7` exists only up to node 22, `s390x` only from node 26. The
list has been unsatisfiable since node 23 went away.

Picked node 22 (LTS, and the newest tag still shipping `arm/v7`) and
dropped `linux/s390x` from the platform list. Final coverage: amd64,
arm/v7, arm64/v8, ppc64le. It satisfies the engines range of
http-proxy-middleware 4 (`^22.15`).

## The npm EACCES failure

#4 added a package-lock.json, which surfaced a pre-existing ordering bug:
the Dockerfile switched to `USER nobody` *before* `npm install`, so npm
could not write the lockfile into the root-owned workdir. Install now
runs as root and privileges are dropped afterwards, so the container
still runs as `nobody`. Also moved to `npm ci --omit=dev` now that a
lockfile exists.

## Latent bug

There was no .dockerignore, so `COPY . .` copied the host node_modules
into the image, overwriting the ones npm had just built for the target
architecture. Silently wrong on every non-native platform. Added one.

## Verification

- `docker buildx build` across all four target platforms: passes.
- Container run and checked: runs as uid 65534 (nobody), proxies a real
  request end-to-end with the right `Access-Control-Allow-Origin`, no
  errors in the logs.